### PR TITLE
Withdraw collateral if 100% token in burnt

### DIFF
--- a/src/hooks/useActiveAndClosedPositions.ts
+++ b/src/hooks/useActiveAndClosedPositions.ts
@@ -145,8 +145,6 @@ export function useActiveAndClosedPositions(
     setSellsLeft(_sells);
     setBuysLeft(_buys);
 
-    console.log(positionsWithInitPremium.filter(p => Number(p.expiry) > Date.now() / 1000))
-
     return {
       activePositionsWithInitPremium: positionsWithInitPremium.filter(p => Number(p.expiry) > Date.now() / 1000),
       expiredPositionsWithInitPremium: positionsWithInitPremium.filter(p => Number(p.expiry) < Date.now() / 1000),


### PR DESCRIPTION
# Pull Request Template

## Description
If the user burns 100% of oToken the vault is disappeared and the user can't able to withdraw collateral directly. In this fix collateral will be withdrawn if 100% of the token is burnt.

Fixes #6 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change
