### PR TITLE
Fix payout chart for spread at breakeven

### DIFF
--- a/src/components/Charts/HistoricalPrice.tsx
+++ b/src/components/Charts/HistoricalPrice.tsx
@@ -69,6 +69,7 @@ const chartOptions = {
     intersect: false,
     mode: 'index',
   },
+  animation: { duration: 0 },
   hover: { animationDuration: 0, intersect: false },
   onHover: (_: any, elements: any) => {
     if (elements && elements.length) {

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -357,7 +357,7 @@ export function getPayoutDetails(oTokens: OTokenWithTradeDetail[], action: Trade
     const strike1 = oToken1.strikePrice.toNumber();
     const strike2 = oToken2?.strikePrice?.toNumber() || 0;
     const end = (strike2 ? strike2 : strike1) + 2000;
-    const price = netPremium(oTokens, action).toNumber();
+    const price = netPremium(oTokens, action).absoluteValue().toNumber();
 
     const gain = maxGain(oTokens, action)
     const loss = maxLoss(oTokens, action);


### PR DESCRIPTION
Also removed animation for better performance

Before:
<img width="875" alt="Screenshot 2021-08-05 at 3 22 57 PM" src="https://user-images.githubusercontent.com/24666922/128330779-daea3a94-2857-459a-bd6a-4f6d193e8112.png">

After:
<img width="875" alt="Screenshot 2021-08-05 at 3 22 03 PM" src="https://user-images.githubusercontent.com/24666922/128330651-5f0d5c8c-37e7-46b2-af97-a3aa95728b92.png">
